### PR TITLE
V1.18.0 tag with OS changes

### DIFF
--- a/pkg/reconciler/managed/reconciler.go
+++ b/pkg/reconciler/managed/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -637,7 +638,13 @@ func WithMetricRecorder(recorder MetricRecorder) ReconcilerOption {
 // interval.
 type PollIntervalHook func(managed resource.Managed, pollInterval time.Duration) time.Duration
 
-func defaultPollIntervalHook(_ resource.Managed, pollInterval time.Duration) time.Duration {
+func defaultPollIntervalHook(managed resource.Managed, pollInterval time.Duration) time.Duration {
+	if managed != nil &&
+		managed.GetCondition(xpv1.TypeSynced).Status == v1.ConditionTrue &&
+		managed.GetCondition(xpv1.TypeReady).Status == v1.ConditionTrue {
+		jitter := 30 * time.Minute
+		return time.Hour + time.Duration((rand.Float64()-0.5)*2*float64(jitter)).Round(time.Second)
+	}
 	return pollInterval
 }
 
@@ -1359,9 +1366,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (resu
 	// changes, so we requeue a speculative reconcile after the specified poll
 	// interval in order to observe it and react accordingly.
 	// https://github.com/crossplane/crossplane/issues/289
-	reconcileAfter := r.pollIntervalHook(managed, r.pollInterval)
-	log.Debug("Successfully requested update of external resource", "requeue-after", time.Now().Add(reconcileAfter))
+	log.Debug("Successfully requested update of external resource", "requeue-after", time.Now().Add(r.pollInterval))
 	record.Event(managed, event.Normal(reasonUpdated, "Successfully requested update of external resource"))
 	managed.SetConditions(xpv1.ReconcileSuccess())
-	return reconcile.Result{RequeueAfter: reconcileAfter}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
+	return reconcile.Result{RequeueAfter: r.pollInterval}, errors.Wrap(r.client.Status().Update(ctx, managed), errUpdateManagedStatus)
 }

--- a/pkg/reconciler/managed/reconciler_test.go
+++ b/pkg/reconciler/managed/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -2641,6 +2642,108 @@ func TestReconcilerChangeLogs(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.errMessage, tc.args.c.requests[0].GetEntry().GetErrorMessage()); diff != "" {
 				t.Errorf("\nReason: %s\nr.Reconcile(...): -want errMessage, +got errMessage:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestDefaultPollIntervalHook(t *testing.T) {
+	type args struct {
+		duration time.Duration
+		managed  resource.Managed
+	}
+	type want struct {
+		expected time.Duration
+		margin   time.Duration
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ResourceIsNil": {
+			reason: "Should return the default poll interval if the managed resource is nil.",
+			args: args{
+				duration: defaultPollInterval,
+				managed:  nil,
+			},
+			want: want{expected: defaultPollInterval, margin: 0},
+		},
+		"ResourceNotReady": {
+			reason: "Should return the default poll interval if the managed resource is not ready.",
+			args: args{
+				duration: defaultPollInterval,
+				managed: &fake.Managed{
+					ConditionedStatus: xpv1.ConditionedStatus{
+						Conditions: []xpv1.Condition{
+							{
+								Type:   xpv1.TypeReady,
+								Status: v1.ConditionFalse,
+							},
+							{
+								Type:   xpv1.TypeSynced,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			want: want{expected: defaultPollInterval, margin: 0},
+		},
+		"ResourceNotSynced": {
+			reason: "Should return the default poll interval if the managed resource is not synced.",
+			args: args{
+				duration: defaultPollInterval,
+				managed: &fake.Managed{
+					ConditionedStatus: xpv1.ConditionedStatus{
+						Conditions: []xpv1.Condition{
+							{
+								Type:   xpv1.TypeReady,
+								Status: v1.ConditionTrue,
+							},
+							{
+								Type:   xpv1.TypeSynced,
+								Status: v1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+			want: want{expected: defaultPollInterval, margin: 0},
+		},
+		"ResourceReady": {
+			reason: "Should return the provided duration if the managed resource is ready.",
+			args: args{
+				duration: 1 * time.Minute,
+				managed: &fake.Managed{
+					ConditionedStatus: xpv1.ConditionedStatus{
+						Conditions: []xpv1.Condition{
+							{
+								Type:   xpv1.TypeReady,
+								Status: v1.ConditionTrue,
+							},
+							{
+								Type:   xpv1.TypeSynced,
+								Status: v1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			want: want{expected: 1 * time.Hour, margin: 30 * time.Minute},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := defaultPollIntervalHook(tc.args.managed, tc.args.duration)
+			if tc.want.margin == 0 {
+				if diff := cmp.Diff(tc.want.expected, r); diff != "" {
+					t.Errorf("\nReason: %s\ndefaultPollIntervalHook(...): -want, +got:\n%s", tc.reason, diff)
+				}
+			} else {
+				if r < tc.want.expected-tc.want.margin || r > tc.want.expected+tc.want.margin {
+					t.Errorf("defaultPollIntervalHook(...): expected %v, got %v", tc.want.expected, r)
+				}
 			}
 		})
 	}

--- a/pkg/reconciler/managed/reconciler_typed.go
+++ b/pkg/reconciler/managed/reconciler_typed.go
@@ -52,6 +52,7 @@ func (c *typedExternalClientWrapper[managed]) Create(ctx context.Context, mg res
 	}
 	return c.c.Create(ctx, cr)
 }
+
 func (c *typedExternalClientWrapper[managed]) Update(ctx context.Context, mg resource.Managed) (ExternalUpdate, error) {
 	cr, ok := mg.(managed)
 	if !ok {

--- a/pkg/resource/fake/mocks.go
+++ b/pkg/resource/fake/mocks.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 )
 
 // Conditioned is a mock that implements Conditioned interface.
@@ -50,13 +50,13 @@ func (m *Conditioned) GetCondition(ct xpv1.ConditionType) xpv1.Condition {
 }
 
 // ClaimReferencer is a mock that implements ClaimReferencer interface.
-type ClaimReferencer struct{ Ref *claim.Reference }
+type ClaimReferencer struct{ Ref *reference.Claim }
 
 // SetClaimReference sets the ClaimReference.
-func (m *ClaimReferencer) SetClaimReference(r *claim.Reference) { m.Ref = r }
+func (m *ClaimReferencer) SetClaimReference(r *reference.Claim) { m.Ref = r }
 
 // GetClaimReference gets the ClaimReference.
-func (m *ClaimReferencer) GetClaimReference() *claim.Reference { return m.Ref }
+func (m *ClaimReferencer) GetClaimReference() *reference.Claim { return m.Ref }
 
 // ManagedResourceReferencer is a mock that implements ManagedResourceReferencer interface.
 type ManagedResourceReferencer struct{ Ref *corev1.ObjectReference }
@@ -184,15 +184,15 @@ func (m *CompositionSelector) SetCompositionSelector(s *metav1.LabelSelector) { 
 func (m *CompositionSelector) GetCompositionSelector() *metav1.LabelSelector { return m.Sel }
 
 // CompositionRevisionReferencer is a mock that implements CompositionRevisionReferencer interface.
-type CompositionRevisionReferencer struct{ Ref *corev1.ObjectReference }
+type CompositionRevisionReferencer struct{ Ref *corev1.LocalObjectReference }
 
 // SetCompositionRevisionReference sets the CompositionRevisionReference.
-func (m *CompositionRevisionReferencer) SetCompositionRevisionReference(r *corev1.ObjectReference) {
+func (m *CompositionRevisionReferencer) SetCompositionRevisionReference(r *corev1.LocalObjectReference) {
 	m.Ref = r
 }
 
 // GetCompositionRevisionReference gets the CompositionRevisionReference.
-func (m *CompositionRevisionReferencer) GetCompositionRevisionReference() *corev1.ObjectReference {
+func (m *CompositionRevisionReferencer) GetCompositionRevisionReference() *corev1.LocalObjectReference {
 	return m.Ref
 }
 
@@ -236,13 +236,13 @@ func (m *CompositeResourceDeleter) GetCompositeDeletePolicy() *xpv1.CompositeDel
 }
 
 // CompositeResourceReferencer is a mock that implements CompositeResourceReferencer interface.
-type CompositeResourceReferencer struct{ Ref *corev1.ObjectReference }
+type CompositeResourceReferencer struct{ Ref *reference.Composite }
 
 // SetResourceReference sets the composite resource reference.
-func (m *CompositeResourceReferencer) SetResourceReference(p *corev1.ObjectReference) { m.Ref = p }
+func (m *CompositeResourceReferencer) SetResourceReference(p *reference.Composite) { m.Ref = p }
 
 // GetResourceReference gets the composite resource reference.
-func (m *CompositeResourceReferencer) GetResourceReference() *corev1.ObjectReference { return m.Ref }
+func (m *CompositeResourceReferencer) GetResourceReference() *reference.Composite { return m.Ref }
 
 // ComposedResourcesReferencer is a mock that implements ComposedResourcesReferencer interface.
 type ComposedResourcesReferencer struct{ Refs []corev1.ObjectReference }

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"context"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 )
 
 // A Conditioned may have conditions set or retrieved. Conditions are typically
@@ -37,8 +37,8 @@ type Conditioned interface {
 
 // A ClaimReferencer may reference a resource claim.
 type ClaimReferencer interface {
-	SetClaimReference(r *claim.Reference)
-	GetClaimReference() *claim.Reference
+	SetClaimReference(r *reference.Claim)
+	GetClaimReference() *reference.Claim
 }
 
 // A ManagedResourceReferencer may reference a concrete managed resource.

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"context"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 )
 
 // A Conditioned may have conditions set or retrieved. Conditions are typically
@@ -120,8 +120,8 @@ type CompositionReferencer interface {
 // A CompositionRevisionReferencer may reference a specific revision of a
 // composition of resources.
 type CompositionRevisionReferencer interface {
-	SetCompositionRevisionReference(ref *corev1.ObjectReference)
-	GetCompositionRevisionReference() *corev1.ObjectReference
+	SetCompositionRevisionReference(ref *corev1.LocalObjectReference)
+	GetCompositionRevisionReference() *corev1.LocalObjectReference
 }
 
 // A CompositionRevisionSelector may reference a set of
@@ -153,8 +153,8 @@ type ComposedResourcesReferencer interface {
 
 // A CompositeResourceReferencer can reference a composite resource.
 type CompositeResourceReferencer interface {
-	SetResourceReference(r *corev1.ObjectReference)
-	GetResourceReference() *corev1.ObjectReference
+	SetResourceReference(r *reference.Composite)
+	GetResourceReference() *reference.Composite
 }
 
 // An EnvironmentConfigReferencer references a list of EnvironmentConfigs.

--- a/pkg/resource/unstructured/claim/claim.go
+++ b/pkg/resource/unstructured/claim/claim.go
@@ -18,6 +18,7 @@ limitations under the License.
 package claim
 
 import (
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -61,21 +62,6 @@ func New(opts ...Option) *Unstructured {
 // An Unstructured composite resource claim.
 type Unstructured struct {
 	unstructured.Unstructured
-}
-
-// Reference to a claim.
-type Reference struct {
-	// APIVersion of the referenced claim.
-	APIVersion string `json:"apiVersion"`
-
-	// Kind of the referenced claim.
-	Kind string `json:"kind"`
-
-	// Name of the referenced claim.
-	Name string `json:"name"`
-
-	// Namespace of the referenced claim.
-	Namespace string `json:"namespace"`
 }
 
 // GetUnstructured returns the underlying *unstructured.Unstructured.
@@ -170,8 +156,8 @@ func (c *Unstructured) GetCompositeDeletePolicy() *xpv1.CompositeDeletePolicy {
 }
 
 // GetResourceReference of this composite resource claim.
-func (c *Unstructured) GetResourceReference() *corev1.ObjectReference {
-	out := &corev1.ObjectReference{}
+func (c *Unstructured) GetResourceReference() *reference.Composite {
+	out := &reference.Composite{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.resourceRef", out); err != nil {
 		return nil
 	}
@@ -179,13 +165,13 @@ func (c *Unstructured) GetResourceReference() *corev1.ObjectReference {
 }
 
 // SetResourceReference of this composite resource claim.
-func (c *Unstructured) SetResourceReference(ref *corev1.ObjectReference) {
+func (c *Unstructured) SetResourceReference(ref *reference.Composite) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.resourceRef", ref)
 }
 
 // GetReference returns reference to this claim.
-func (c *Unstructured) GetReference() *Reference {
-	return &Reference{
+func (c *Unstructured) GetReference() *reference.Claim {
+	return &reference.Claim{
 		APIVersion: c.GetAPIVersion(),
 		Kind:       c.GetKind(),
 		Name:       c.GetName(),

--- a/pkg/resource/unstructured/claim/claim.go
+++ b/pkg/resource/unstructured/claim/claim.go
@@ -18,7 +18,6 @@ limitations under the License.
 package claim
 
 import (
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,6 +25,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 )
 
 // An Option modifies an unstructured composite resource claim.
@@ -98,8 +98,8 @@ func (c *Unstructured) SetCompositionReference(ref *corev1.ObjectReference) {
 }
 
 // GetCompositionRevisionReference of this resource claim.
-func (c *Unstructured) GetCompositionRevisionReference() *corev1.ObjectReference {
-	out := &corev1.ObjectReference{}
+func (c *Unstructured) GetCompositionRevisionReference() *corev1.LocalObjectReference {
+	out := &corev1.LocalObjectReference{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.compositionRevisionRef", out); err != nil {
 		return nil
 	}
@@ -107,7 +107,7 @@ func (c *Unstructured) GetCompositionRevisionReference() *corev1.ObjectReference
 }
 
 // SetCompositionRevisionReference of this resource claim.
-func (c *Unstructured) SetCompositionRevisionReference(ref *corev1.ObjectReference) {
+func (c *Unstructured) SetCompositionRevisionReference(ref *corev1.LocalObjectReference) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRevisionRef", ref)
 }
 

--- a/pkg/resource/unstructured/claim/claim_test.go
+++ b/pkg/resource/unstructured/claim/claim_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 )
 
 var _ client.Object = &Unstructured{}
@@ -172,11 +173,11 @@ func TestCompositionReference(t *testing.T) {
 }
 
 func TestCompositionRevisionReference(t *testing.T) {
-	ref := &corev1.ObjectReference{Namespace: "ns", Name: "cool"}
+	ref := &corev1.LocalObjectReference{Name: "cool"}
 	cases := map[string]struct {
 		u    *Unstructured
-		set  *corev1.ObjectReference
-		want *corev1.ObjectReference
+		set  *corev1.LocalObjectReference
+		want *corev1.LocalObjectReference
 	}{
 		"NewRef": {
 			u:    New(),
@@ -272,11 +273,11 @@ func TestCompositeDeletePolicy(t *testing.T) {
 }
 
 func TestResourceReference(t *testing.T) {
-	ref := &corev1.ObjectReference{Namespace: "ns", Name: "cool"}
+	ref := &reference.Composite{Name: "cool"}
 	cases := map[string]struct {
 		u    *Unstructured
-		set  *corev1.ObjectReference
-		want *corev1.ObjectReference
+		set  *reference.Composite
+		want *reference.Composite
 	}{
 		"NewRef": {
 			u:    New(),
@@ -297,7 +298,7 @@ func TestResourceReference(t *testing.T) {
 }
 
 func TestClaimReference(t *testing.T) {
-	ref := &Reference{Namespace: "ns", Name: "cool", APIVersion: "foo.com/v1", Kind: "Foo"}
+	ref := &reference.Claim{Namespace: "ns", Name: "cool", APIVersion: "foo.com/v1", Kind: "Foo"}
 	u := &Unstructured{}
 	u.SetName(ref.Name)
 	u.SetNamespace(ref.Namespace)

--- a/pkg/resource/unstructured/composite/composite.go
+++ b/pkg/resource/unstructured/composite/composite.go
@@ -18,6 +18,7 @@ limitations under the License.
 package composite
 
 import (
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,7 +27,6 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
 )
 
 // An Option modifies an unstructured composite resource.
@@ -142,8 +142,8 @@ func (c *Unstructured) GetCompositionUpdatePolicy() *xpv1.UpdatePolicy {
 }
 
 // GetClaimReference of this Composite resource.
-func (c *Unstructured) GetClaimReference() *claim.Reference {
-	out := &claim.Reference{}
+func (c *Unstructured) GetClaimReference() *reference.Claim {
+	out := &reference.Claim{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.claimRef", out); err != nil {
 		return nil
 	}
@@ -151,7 +151,7 @@ func (c *Unstructured) GetClaimReference() *claim.Reference {
 }
 
 // SetClaimReference of this Composite resource.
-func (c *Unstructured) SetClaimReference(ref *claim.Reference) {
+func (c *Unstructured) SetClaimReference(ref *reference.Claim) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.claimRef", ref)
 }
 
@@ -175,6 +175,15 @@ func (c *Unstructured) SetResourceReferences(refs []corev1.ObjectReference) {
 		filtered = append(filtered, ref)
 	}
 	_ = fieldpath.Pave(c.Object).SetValue("spec.resourceRefs", filtered)
+}
+
+// GetReference returns reference to this composite.
+func (c *Unstructured) GetReference() *reference.Composite {
+	return &reference.Composite{
+		APIVersion: c.GetAPIVersion(),
+		Kind:       c.GetKind(),
+		Name:       c.GetName(),
+	}
 }
 
 // GetWriteConnectionSecretToReference of this Composite resource.

--- a/pkg/resource/unstructured/composite/composite.go
+++ b/pkg/resource/unstructured/composite/composite.go
@@ -18,7 +18,6 @@ limitations under the License.
 package composite
 
 import (
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,6 +26,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 )
 
 // An Option modifies an unstructured composite resource.
@@ -99,8 +99,8 @@ func (c *Unstructured) SetCompositionReference(ref *corev1.ObjectReference) {
 }
 
 // GetCompositionRevisionReference of this Composite resource.
-func (c *Unstructured) GetCompositionRevisionReference() *corev1.ObjectReference {
-	out := &corev1.ObjectReference{}
+func (c *Unstructured) GetCompositionRevisionReference() *corev1.LocalObjectReference {
+	out := &corev1.LocalObjectReference{}
 	if err := fieldpath.Pave(c.Object).GetValueInto("spec.compositionRevisionRef", out); err != nil {
 		return nil
 	}
@@ -108,7 +108,7 @@ func (c *Unstructured) GetCompositionRevisionReference() *corev1.ObjectReference
 }
 
 // SetCompositionRevisionReference of this Composite resource.
-func (c *Unstructured) SetCompositionRevisionReference(ref *corev1.ObjectReference) {
+func (c *Unstructured) SetCompositionRevisionReference(ref *corev1.LocalObjectReference) {
 	_ = fieldpath.Pave(c.Object).SetValue("spec.compositionRevisionRef", ref)
 }
 

--- a/pkg/resource/unstructured/composite/composite_test.go
+++ b/pkg/resource/unstructured/composite/composite_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/claim"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/reference"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
@@ -259,11 +259,11 @@ func TestCompositionReference(t *testing.T) {
 }
 
 func TestCompositionRevisionReference(t *testing.T) {
-	ref := &corev1.ObjectReference{Namespace: "ns", Name: "cool"}
+	ref := &corev1.LocalObjectReference{Name: "cool"}
 	cases := map[string]struct {
 		u    *Unstructured
-		set  *corev1.ObjectReference
-		want *corev1.ObjectReference
+		set  *corev1.LocalObjectReference
+		want *corev1.LocalObjectReference
 	}{
 		"NewRef": {
 			u:    New(),
@@ -334,11 +334,11 @@ func TestCompositionUpdatePolicy(t *testing.T) {
 }
 
 func TestClaimReference(t *testing.T) {
-	ref := &claim.Reference{Namespace: "ns", Name: "cool", APIVersion: "acme.com/v1", Kind: "Foo"}
+	ref := &reference.Claim{Namespace: "ns", Name: "cool", APIVersion: "acme.com/v1", Kind: "Foo"}
 	cases := map[string]struct {
 		u    *Unstructured
-		set  *claim.Reference
-		want *claim.Reference
+		set  *reference.Claim
+		want *reference.Claim
 	}{
 		"NewRef": {
 			u:    New(),

--- a/pkg/resource/unstructured/reference/reference.go
+++ b/pkg/resource/unstructured/reference/reference.go
@@ -1,0 +1,28 @@
+package reference
+
+// A Claim is a reference to a claim.
+type Claim struct {
+	// APIVersion of the referenced claim.
+	APIVersion string `json:"apiVersion"`
+
+	// Kind of the referenced claim.
+	Kind string `json:"kind"`
+
+	// Name of the referenced claim.
+	Name string `json:"name"`
+
+	// Namespace of the referenced claim.
+	Namespace string `json:"namespace"`
+}
+
+// A Composite is a reference to a composite.
+type Composite struct {
+	// APIVersion of the referenced composite.
+	APIVersion string `json:"apiVersion"`
+
+	// Kind of the referenced composite.
+	Kind string `json:"kind"`
+
+	// Name of the referenced composite.
+	Name string `json:"name"`
+}

--- a/pkg/resource/unstructured/reference/reference.go
+++ b/pkg/resource/unstructured/reference/reference.go
@@ -1,4 +1,25 @@
+/*
+Copyright 2024 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package reference contains references to resources.
 package reference
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 // A Claim is a reference to a claim.
 type Claim struct {
@@ -25,4 +46,14 @@ type Composite struct {
 
 	// Name of the referenced composite.
 	Name string `json:"name"`
+}
+
+// GroupVersionKind returns the GroupVersionKind of the claim reference.
+func (c *Claim) GroupVersionKind() schema.GroupVersionKind {
+	return schema.FromAPIVersionAndKind(c.APIVersion, c.Kind)
+}
+
+// GroupVersionKind returns the GroupVersionKind of the composite reference.
+func (c *Composite) GroupVersionKind() schema.GroupVersionKind {
+	return schema.FromAPIVersionAndKind(c.APIVersion, c.Kind)
 }


### PR DESCRIPTION
I've:

crossplane-runtime change from v1.16.0 to v1.18.0 required on https://github.com/OutSystems/cloud-provisioner-aws/pull/98
fetched all tags from crossplane/crossplane-runtime to this repo `git fetch --tags upstream and git push --tags`
created a branch `v1.18.0-tag` from tag `v1.18.0` `git checkout -b v1.18.0-tag v1.18.0`
created another branch `v1.18.0-tag-with-os-changes` `git checkout -b v1.18.0-tag-with-os-changes`
created this PR to get the OS changes from `feat/override-default-poll-interval-hook` to `v1.18.0-tag-with-os-changes`
next steps: update the `https://github.com/OutSystems/cloud-provisioner-aws/` to point to commit created by this PR.